### PR TITLE
Disable master in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,16 @@ matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
            ALT=i686-unknown-linux-gnu
+      if: branch != master OR type = pull_request
     - env: TARGET=x86_64-apple-darwin
            ALT=i686-apple-darwin
       os: osx
+      if: branch != master OR type = pull_request
 
     - env: TARGET=x86_64-unknown-linux-gnu
            ALT=i686-unknown-linux-gnu
       rust: beta
+      if: branch != master OR type = pull_request
 
     # Minimum Rust supported channel. We enable these to make sure we
     # continue to work on the advertised minimum Rust version.
@@ -38,6 +41,7 @@ matrix:
         - cargo +nightly generate-lockfile -Z minimal-versions
         - cargo -V
         - cargo test
+      if: branch != master OR type = pull_request
 
     - env: TARGET=x86_64-unknown-linux-gnu
            ALT=i686-unknown-linux-gnu
@@ -48,6 +52,7 @@ matrix:
         - cargo test
         - cargo doc --no-deps
         - (cd src/doc && mdbook build --dest-dir ../../target/doc)
+      if: branch != master OR type = pull_request
 
   exclude:
     - rust: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     CFG_DISABLE_CROSS_TESTS: 1
 
 install:
+  - if NOT defined APPVEYOR_PULL_REQUEST_NUMBER if "%APPVEYOR_REPO_BRANCH%" == "master" exit
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin


### PR DESCRIPTION
There's no need to build and test the exact same commit twice between
bors's auto branch and master. Hopefully this will help reduce the
bors timeouts due to waiting on appveyor.